### PR TITLE
fixed minor bug in initialise_routines.R

### DIFF
--- a/R/initialise_routines.R
+++ b/R/initialise_routines.R
@@ -6,7 +6,7 @@ run_initialise_routines <- function(user_run_params = NULL, user_variable_params
   #' @import abind
   #' @import pixmap
   
-  if (!is.null(user_run_params) && user_params$overwrite_default_params == TRUE){
+  if (!is.null(user_run_params) && user_run_params$overwrite_default_params == TRUE){
     run_params <- overwrite_current_params(user_run_params, default_params = initialise_default_run_params())
     variable_params <- overwrite_current_params(user_params = user_variable_params, default_params = initialise_default_variable_params())
   }


### PR DESCRIPTION
Fixed a rather trivial bug in run_initialise_routines() that was causing the osim.run() calls to crash.  