### PR TITLE
Run by derivatives fix to catch crash that can happen when user changes number of time steps

### DIFF
--- a/R/collate_routines.R
+++ b/R/collate_routines.R
@@ -277,6 +277,7 @@ build_site_features_at_intervention <- function(land_site_num, current_data_dir,
 
 calc_landscape_characteristics <- function(site_scale_outcomes, background_cfacs, use_offset_metric){
 
+  # browser()
   landscape_scale_object = list()
   landscape_scale_object$background_cfacs = background_cfacs
   landscape_scale_object$landscape_outcome = sum_list(site_scale_outcomes)

--- a/R/default_params.R
+++ b/R/default_params.R
@@ -262,7 +262,7 @@ initialise_default_simulation_params <- function(){
   
   # allow pass of credit to simulation - can be used to run developments without offsets
   default_simulation_params$initial_credit = 0
-  default_simulation_params$transform_initial_credit = TRUE
+  default_simulation_params$transform_initial_credit = FALSE
   return(default_simulation_params)
 }
 

--- a/R/simulation_routines.R
+++ b/R/simulation_routines.R
@@ -108,6 +108,8 @@ osim.run <- function(user_global_params = NULL, user_simulation_params = NULL, u
   
   flog.info('running collate routines')
   
+  # browser()
+  
   if ((simulation_data_object$global_params$overwrite_feature_dynamics == TRUE) |
       !file.exists(paste0(simulation_data_object$global_params$simulation_inputs_folder, 'background_cfacs.rds'))){
       flog.info('building background counterfactuals - this may take a while')
@@ -115,8 +117,21 @@ osim.run <- function(user_global_params = NULL, user_simulation_params = NULL, u
       flog.info('saving background counterfactuals')
       saveRDS(background_cfacs_object, paste0(simulation_data_object$global_params$simulation_inputs_folder, 'background_cfacs.rds'))
   } else {
+    
     flog.info('loading background counterfactuals from file')
     background_cfacs_object = readRDS(paste0(simulation_data_object$global_params$simulation_inputs_folder, 'background_cfacs.rds'))
+    
+    # new code added by Ascelin (which Isaac's guidance) to catch case when the user is changing time steps 
+    # but the number stored background_cfacs.rds object was generated with a different number of time steps.
+    if(simulation_data_object$simulation_params$time_steps != dim(background_cfacs_object$background_cfacs[[1]])[1] ){
+      
+      flog.warn('User defined number of time steps does not match time steps in background_cfacs_object (background_cfacs.rds).
+                 ... Building background_cfacs_object from scratch (to avoid this warning set global_params$overwrite_feature_dynamics to TRUE')
+      
+      background_cfacs_object = build_background_cfacs(simulation_data_object)
+      
+    }
+    
   }
     
   if ((simulation_data_object$global_params$number_of_cores > 1) && (simulation_data_object$global_params$realisation_num > 1)){
@@ -1312,7 +1327,9 @@ match_sites <- function(simulation_data_object, match_type, yr){
     } else if (simulation_data_object$simulation_params$development_selection_type == 'weighted'){
       current_dev_probability_list = recalculate_probabilities(simulation_data_object$dev_probability_list[unlist(current_match_pool)])
     } 
-
+    
+    
+    # todo: possible crash due to pool containing one site, loop needs to break before this happens.
     sample_ind = sample(x = seq_along(current_match_pool), size = 1, prob = current_dev_probability_list, replace = TRUE)
     current_test_index = current_match_pool[sample_ind]
     vals_to_match = current_match_vals_pool[[sample_ind]]


### PR DESCRIPTION
New code added by Ascelin (which Isaac's guidance) to catch case when the user is changing time steps, but the number stored background_cfacs.rds object was generated with a different number of time steps.